### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/resources/js/Pages/Products/product_edit.jsx
+++ b/resources/js/Pages/Products/product_edit.jsx
@@ -107,10 +107,12 @@ export default function EditProduct() {
 
     const handleImageChange = (e) => {
         const file = e.target.files[0];
-        if (file) {
+        if (file && file.type.startsWith('image/')) {
             setData('image', file);
             setImagePreview(URL.createObjectURL(file));
             setImageName(file.name);
+        } else {
+            alert('Please select a valid image file.');
         }
     };
 


### PR DESCRIPTION
Fixes [https://github.com/ChamudikaDeSilva/Admin-panel/security/code-scanning/4](https://github.com/ChamudikaDeSilva/Admin-panel/security/code-scanning/4)

To fix the problem, we should ensure that the file being used for the image preview is indeed a valid image file. This can be done by checking the file type before setting the `imagePreview` state. Additionally, we can use a library like `DOMPurify` to sanitize any URLs or content if needed.

- Validate the file type to ensure it is an image before setting the `imagePreview` state.
- Update the `handleImageChange` function to include this validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
