### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/resources/js/Pages/Products/product.jsx
+++ b/resources/js/Pages/Products/product.jsx
@@ -88,8 +88,14 @@ export default function Products({ auth }) {
 
     const handleImageChange = (e) => {
         const file = e.target.files[0];
-        setFormData({ ...formData, image: file });
-        setImagePreview(URL.createObjectURL(file));
+        if (file && file.type.startsWith('image/')) {
+            setFormData({ ...formData, image: file });
+            setImagePreview(URL.createObjectURL(file));
+        } else {
+            setFormData({ ...formData, image: null });
+            setImagePreview(null);
+            alert('Please select a valid image file.');
+        }
     };
 
     const handleSubmit = async (e) => {


### PR DESCRIPTION
Fixes [https://github.com/ChamudikaDeSilva/Admin-panel/security/code-scanning/3](https://github.com/ChamudikaDeSilva/Admin-panel/security/code-scanning/3)

To fix the problem, we need to ensure that the `imagePreview` URL is safe and cannot be manipulated to include malicious content. One way to achieve this is by validating the file type before creating the object URL and using it in the `img` tag. We can also add additional checks to ensure the file is an image.

- Validate the file type to ensure it is an image before creating the object URL.
- Update the `handleImageChange` function to include this validation.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
